### PR TITLE
Update disciplines in Neurona section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,16 +18,18 @@ import Neurona from '../components/Neurona.astro';
 		<!-- Sección Neurociencias -->
 		<h1 class="text-center text-4xl font-semibold pt-10 pb-5 animate-zoom-in timeline-view animate-range-[entry_20%_cover_25%]">Nuestra Red de Disciplinas</h1>
 		<div class="flex flex-wrap gap-15 py-10 px-15 max-sm:gap-5 max-sm:px-1 justify-center items-center">
-			<Neurona title="Matematicas"/>
 			<Neurona title="Neurología"/>
+			<Neurona title="Psiquiatría"/>
+			<Neurona title="Neuro-psicología"/>
+			<Neurona title="Paido-psiquiatría"/>
+			<Neurona title="Matematicas"/>
 			<Neurona title="Rehabilitación"/>
 			<Neurona title="Neuroimagen"/>
 			<Neurona title="Genética"/>
 			<Neurona title="Psicología"/>
 			<Neurona title="Bioquímica"/>
 			<Neurona title="Ingeniería biomédica"/>
-			<Neurona title="Paido-psiquiatría"/>
-			<Neurona title="Neuro-pediatría"/>
+			<Neurona title="Neuropediatría"/>
 		</div>
 	</main>
 </Layout>


### PR DESCRIPTION
This pull request updates the order and titles of disciplines displayed in the "Nuestra Red de Disciplinas" section on the homepage. The changes improve the organization and accuracy of the disciplines listed.

CLOSES: #6 

Content and display improvements:

* Reordered the `Neurona` components to group similar disciplines together and provide a more logical flow.
* Added new disciplines: "Psiquiatría", "Neuro-psicología", and "Neuropediatría", while updating "Neuro-pediatría" to "Neuropediatría" for consistency.
* Adjusted the placement of "Matematicas" and "Paido-psiquiatría" to better fit the thematic grouping.Reordered and added new disciplines in the 'Nuestra Red de Disciplinas' section.

Added 'Psiquiatría', 'Neuro-psicología', and updated 'Neuro-pediatría' to 'Neuropediatría' for improved clarity and completeness.